### PR TITLE
Version bump script

### DIFF
--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,7 +1,7 @@
 class PactRubyStandalone < Formula
     desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
     homepage "https://github.com/pact-foundation/pact-ruby-standalone"
-    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/1.67.0/pact-1.67.0-osx.tar.gz"
+    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.67.0/pact-1.67.0-osx.tar.gz"
     version "1.67.0"
     sha256 "6a7e789477ec14a5dda61010e4460b1007c02719bdcfe25e789549b6e5497add"
 

--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,22 +1,22 @@
 class PactRubyStandalone < Formula
-    desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
-    homepage "https://github.com/pact-foundation/pact-ruby-standalone"
-    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.67.0/pact-1.67.0-osx.tar.gz"
-    version "1.67.0"
-    sha256 "6a7e789477ec14a5dda61010e4460b1007c02719bdcfe25e789549b6e5497add"
+  desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
+  homepage "https://github.com/pact-foundation/pact-ruby-standalone"
+  url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.67.0/pact-1.67.0-osx.tar.gz"
+  version "1.67.0"
+  sha256 "6a7e789477ec14a5dda61010e4460b1007c02719bdcfe25e789549b6e5497add"
 
-    def install
-        bin.install Dir["bin/*"]
-        lib.install Dir["lib/*"]
+  def install
+    bin.install Dir["bin/*"]
+    lib.install Dir["lib/*"]
 
-        puts "# Usage: pact-mock-service help [COMMAND]"
-        puts "#"
-        puts "# For other tools related to PACT in this bundle see https://github.com/pact-foundation/pact-ruby-standalone/releases/"
-        puts "#"
-    end
+    puts "# Usage: pact-mock-service help [COMMAND]"
+    puts "#"
+    puts "# For other tools related to PACT in this bundle see https://github.com/pact-foundation/pact-ruby-standalone/releases/"
+    puts "#"
+  end
 
-    test do
-        system "#{bin}/pact-mock-service", "help"
-    end
+  test do
+    system "#{bin}/pact-mock-service", "help"
+  end
 
 end

--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,22 +1,22 @@
 class PactRubyStandalone < Formula
-  desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
-  homepage "https://github.com/pact-foundation/pact-ruby-standalone/"
-  url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.67.0/pact-1.67.0-osx.tar.gz"
-  version "1.67.0"
-  sha256 "6a7e789477ec14a5dda61010e4460b1007c02719bdcfe25e789549b6e5497add"
+    desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
+    homepage "https://github.com/pact-foundation/pact-ruby-standalone"
+    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/1.64.0/pact-1.64.0-osx.tar.gz"
+    version "1.64.0"
+    sha256 "1074ab2693c4a2f45ce48a0d9e32f1510dadf8a997ae4c74eb98c808eab6bc65"
 
-  def install
-    bin.install Dir["bin/*"]
-    lib.install Dir["lib/*"]
+    def install
+        bin.install Dir["bin/*"]
+        lib.install Dir["lib/*"]
 
-    puts "# Usage `pact-mock-service help [COMMAND]`"
-    puts "#"
-    puts "# For other tools related to PACT in this bundle see https://github.com/pact-foundation/pact-ruby-standalone/releases/"
-    puts "#"
-  end
+        puts "# Usage: pact-mock-service help [COMMAND]"
+        puts "#"
+        puts "# For other tools related to PACT in this bundle see https://github.com/pact-foundation/pact-ruby-standalone/releases/"
+        puts "#"
+    end
 
-  test do
-    system "#{bin}/pact-mock-service", "help"
-  end
+    test do
+        system "#{bin}/pact-mock-service", "help"
+    end
 
 end

--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,9 +1,9 @@
 class PactRubyStandalone < Formula
     desc "A standalone pact command line executable using the ruby pact implementation and Travelling Ruby"
     homepage "https://github.com/pact-foundation/pact-ruby-standalone"
-    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/1.64.0/pact-1.64.0-osx.tar.gz"
-    version "1.64.0"
-    sha256 "1074ab2693c4a2f45ce48a0d9e32f1510dadf8a997ae4c74eb98c808eab6bc65"
+    url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/1.67.0/pact-1.67.0-osx.tar.gz"
+    version "1.67.0"
+    sha256 "6a7e789477ec14a5dda61010e4460b1007c02719bdcfe25e789549b6e5497add"
 
     def install
         bin.install Dir["bin/*"]

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -3,7 +3,7 @@ set -e
 
 homepage="https://github.com/pact-foundation/pact-ruby-standalone"
 version=$1
-FORMULAE_FILE="pact-ruby-standalone.rb"
+FORMULAE_FILE="../pact-ruby-standalone.rb"
 
 write_homebrew_formulae() {    
     if [ ! -f "$FORMULAE_FILE" ] ; then
@@ -52,6 +52,11 @@ else
     echo "Writing formulae..."
 
     write_homebrew_formulae
+
+    echo "Sorting out the repo..."
+    git add $FORMULAE_FILE
+    git commit -m "Release of version $version"
+    # git push origin
 
     echo "Done!"
     exit 0

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -14,25 +14,25 @@ write_homebrew_formulae() {
 
      exec 3<> $FORMULAE_FILE
         echo "class PactRubyStandalone < Formula" >&3
-        echo "    desc \"A standalone pact command line executable using the ruby pact implementation and Travelling Ruby\"" >&3
-        echo "    homepage \"$homepage\"" >&3
-        echo "    url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
-        echo "    version \"$version\"" >&3
-        echo "    sha256 \"${shasignature[1]}\"" >&3
+        echo "  desc \"A standalone pact command line executable using the ruby pact implementation and Travelling Ruby\"" >&3
+        echo "  homepage \"$homepage\"" >&3
+        echo "  url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
+        echo "  version \"$version\"" >&3
+        echo "  sha256 \"${shasignature[1]}\"" >&3
         echo "" >&3
-        echo "    def install" >&3
-        echo "        bin.install Dir[\"bin/*\"]" >&3
-        echo "        lib.install Dir[\"lib/*\"]" >&3
+        echo "  def install" >&3
+        echo "    bin.install Dir[\"bin/*\"]" >&3
+        echo "    lib.install Dir[\"lib/*\"]" >&3
         echo "" >&3
-        echo "        puts \"# Usage: pact-mock-service help [COMMAND]\"" >&3
-        echo "        puts \"#\"" >&3
-        echo "        puts \"# For other tools related to PACT in this bundle see $homepage/releases/\"" >&3
-        echo "        puts \"#\"" >&3
-        echo "    end" >&3
+        echo "    puts \"# Usage: pact-mock-service help [COMMAND]\"" >&3
+        echo "    puts \"#\"" >&3
+        echo "    puts \"# For other tools related to PACT in this bundle see $homepage/releases/\"" >&3
+        echo "    puts \"#\"" >&3
+        echo "  end" >&3
         echo "" >&3
-        echo "    test do" >&3
-        echo "        system \"#{bin}/pact-mock-service\", \"help\"" >&3
-        echo "    end" >&3
+        echo "  test do" >&3
+        echo "    system \"#{bin}/pact-mock-service\", \"help\"" >&3
+        echo "  end" >&3
         echo "" >&3
         echo "end" >&3
     exec 3>&-

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -3,7 +3,7 @@ set -e
 
 homepage="https://github.com/pact-foundation/pact-ruby-standalone"
 version=$1
-FORMULAE_FILE="../pact-ruby-standalone.rb"
+FORMULAE_FILE="pact-ruby-standalone.rb"
 
 write_homebrew_formulae() {    
     if [ ! -f "$FORMULAE_FILE" ] ; then
@@ -16,7 +16,7 @@ write_homebrew_formulae() {
         echo "class PactRubyStandalone < Formula" >&3
         echo "    desc \"A standalone pact command line executable using the ruby pact implementation and Travelling Ruby\"" >&3
         echo "    homepage \"$homepage\"" >&3
-        echo "    url \"$homepage/releases/download/$version/pact-$version-osx.tar.gz\"" >&3
+        echo "    url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
         echo "    version \"$version\"" >&3
         echo "    sha256 \"${shasignature[1]}\"" >&3
         echo "" >&3
@@ -53,10 +53,14 @@ else
 
     write_homebrew_formulae
 
-    echo "Sorting out the repo..."
+    echo "Sorting out the repo... "
+    echo "...you are running this script from ./homebrew-pact-ruby-standalone root folder, and NOT on \"master\", right?"
+    git checkout -b version/v$version
     git add $FORMULAE_FILE
-    git commit -m "Release of version $version"
-    # git push origin
+    git commit -m "Release of version v$version"
+    git push -u origin version/v$version
+
+    echo "Go and open that PR now..."
 
     echo "Done!"
     exit 0


### PR DESCRIPTION
As it is currently, run it from root folder of this repo as:

```
./scripts/update_tap_version.sh 1.67.0
```

where 1.67.0 is the version of `pact-ruby-standalone` tarball we want the formulae to install through homebrew tap.

It pulls down the tarball of given version for macOS,
checks for sha256
rewrites the formulae .rb file
checks out a new branch with version number (eg: `v1.67.0`)
stages the changed .rb file
commits the changed .rb file
publishes the new branch here

Manual step... open up a PR so we can review it before it gets released into the wild to wreck havoc! 

Godspeed.