### PR TITLE
fix: Properly escape quotes to fix brew install

### DIFF
--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -24,7 +24,7 @@ write_homebrew_formulae() {
         echo "        bin.install Dir[\"bin/*\"]" >&3
         echo "        lib.install Dir[\"lib/*\"]" >&3
         echo "" >&3
-        echo "        puts \"# Run \"pact-mock-service help [COMMAND]\" (for more see $homepage/releases/)" >&3
+        echo "        puts \"# Run \\\"pact-mock-service help [COMMAND]\\\" (for more see $homepage/releases/)\"" >&3
         echo "    end" >&3
         echo "" >&3
         echo "    test do" >&3


### PR DESCRIPTION
brew install fails:

```
$  brew install pact-ruby-standalone
Error: pact-ruby-standalone: /usr/local/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/pact-ruby-standalone.rb:12: syntax error, unexpected tIDENTIFIER, expecting end
        puts "# Run "pact-mock-service help [COMMAND]"...
                     ^~~~
/usr/local/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/pact-ruby-standalone.rb:12: syntax error, unexpected tIDENTIFIER, expecting do or '{' or '('
... "# Run "pact-mock-service help [COMMAND]" (for more see htt...
...                           ^~~~
/usr/local/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/pact-ruby-standalone.rb:12: syntax error, unexpected tSTRING_BEG, expecting end
...ct-mock-service help [COMMAND]" (for more see https://github...
...                              ^
```

This PR fixes escaping quotes.