### PR TITLE
chore(ci): brew pull deprecated for hub checkout https://brew.sh/2020…

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Verify tap (⚠️ experimental ⚠️)
         run: |
-          brew pull ${{ github.event.issue.number }}
+          brew install hub
+          hub checkout ${{ github.event.issue.number }}
           brew install --verbose --debug pact-ruby-standalone
           brew audit --strict --online pact-ruby-standalone


### PR DESCRIPTION
…/06/11/homebrew-2.4.0/