### PR TITLE
chore(ci): verify tap in PR

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Verify tap (⚠️ experimental ⚠️)
         run: |
-          brew install hub
-          hub checkout ${{ github.event.issue.number }}
+          hub checkout version/${{ github.event.issue.number }}
           brew install --verbose --debug pact-ruby-standalone
           brew audit --strict --online pact-ruby-standalone

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -14,10 +14,9 @@ write_homebrew_formulae() {
 
      exec 3<> $FORMULAE_FILE
         echo "class PactRubyStandalone < Formula" >&3
-        echo "  desc \"Standalone pact command-line executable using the Ruby Pact implementation and Travelling Ruby\"" >&3
+        echo "  desc \"Standalone pact CLI executable using the Ruby Pact impl and Travelling Ruby\"" >&3
         echo "  homepage \"$homepage\"" >&3
         echo "  url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
-        echo "  version \"$version\"" >&3
         echo "  sha256 \"${brewshasignature[1]}\"" >&3
         echo "" >&3
         echo "  def install" >&3


### PR DESCRIPTION
Trying to fix the verify tap step when PR's are raised.

-`brew pull` was deprecated and replaced by `hub checkout` https://brew.sh/2020/06/11/homebrew-2.4.0/
- need to update the pull request ref to use version/ prefix to ensure correct PR checked out - https://hub.github.com/hub-checkout.1.html
- some audit failures

```
pact-ruby-standalone:
  * 2: col 3: Description is too long. It should be less than 80 characters. The current length is 94.
  * Stable: version 1.91.0 is redundant with version scanned from URL
  * Libraries were compiled with a flat namespace.
    This can cause linker errors due to name collisions, and
    is often due to a bug in detecting the macOS version.
      /opt/homebrew/Cellar/pact-ruby-standalone/1.91.0/lib/ruby/lib/libyaml-0.2.dylib
```

Have fixed

- Description
- Version https://github.com/Homebrew/legacy-homebrew/issues/32540

That third is a bit different `Libraries were compiled with a flat namespace` and can't find much on info on it
- https://github.com/Homebrew/discussions/discussions/4091