### PR TITLE
Feat: Linux x86 64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test versions
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    strategy:
+      matrix:
+        os: [macOS-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install tap
+        run: |
+          brew tap pact-foundation/pact-ruby-standalone
+          cd $(brew --prefix)/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/
+          hub checkout ${{ github.sha }}
+          brew install --verbose --debug pact-ruby-standalone
+
+      - name: Test tap
+        run: |
+          pact
+          pact-broker --help
+          pact-message --help
+          pact-mock-service --help
+          pact-plugin-cli --help
+          pact-provider-verifier --help
+          pact-stub-service --help
+          pactflow --help
+
+      - name: Audit tap (⚠️ experimental ⚠️) - so we ignore the error code 
+        run: |
+          brew audit --strict --online --installed pact-ruby-standalone || true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     name: test
     strategy:
       matrix:
-        os: [macOS-latest]
+        os: [macOS-latest,ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -17,12 +17,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: install homebrew
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        if: ${{ runner.os == 'Linux' }}
+
       - name: Install tap
         run: |
-          brew tap pact-foundation/pact-ruby-standalone
-          cd $(brew --prefix)/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/
+          brew tap you54f/pact-ruby-standalone
+          cd $(brew --prefix)/Homebrew/Library/Taps/you54f/homebrew-pact-ruby-standalone/
           hub checkout ${{ github.sha }}
           brew install --verbose --debug pact-ruby-standalone
+
+      - name: Brew test tap
+        run: |
+          brew test pact-ruby-standalone
 
       - name: Test tap
         run: |
@@ -34,8 +44,9 @@ jobs:
           pact-provider-verifier --help
           pact-stub-service --help
           pactflow --help
+        
 
       - name: Audit tap (⚠️ experimental ⚠️) - so we ignore the error code 
         run: |
-          brew audit --strict --online --installed pact-ruby-standalone || true
+          brew audit --strict --online pact-ruby-standalone || true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install tap
         run: |
-          brew tap you54f/pact-ruby-standalone
-          cd $(brew --prefix)/Homebrew/Library/Taps/you54f/homebrew-pact-ruby-standalone/
+          brew tap pact-foundation/pact-ruby-standalone
+          cd $(brew --prefix)/Homebrew/Library/Taps/pact-foundation/homebrew-pact-ruby-standalone/
           hub checkout ${{ github.sha }}
           brew install --verbose --debug pact-ruby-standalone
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,3 +25,4 @@ jobs:
           ./scripts/update_tap_version.sh ${{ github.event.client_payload.version }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CREATE_PR: true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -25,9 +25,3 @@ jobs:
           ./scripts/update_tap_version.sh ${{ github.event.client_payload.version }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
-      - name: Verify tap (⚠️ experimental ⚠️)
-        run: |
-          hub checkout version/v${{ github.event.client_payload.version }}
-          brew install --verbose --debug pact-ruby-standalone.rb
-          brew audit --strict --online pact-ruby-standalone

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ The easier way to install [`mock-pact-service`](https://github.com/pact-foundati
 
     brew tap pact-foundation/pact-ruby-standalone
     brew install pact-ruby-standalone
+
+##  Supported Platforms
+
+| OS           | Architecture | Supported |
+| ------- | ------------ | --------- |
+| OSX        | x86_64       | ✅         |
+| OSX        | aarch64 (arm)| ✅       |
+| Linux    | x86_64       | ✅         |
+
+
+### Notes
+
+OSX ARM (M1/M2) Machines will require Rosetta tools, as the Ruby binaries as currently built for x86_64.
+
+If you don't already have it installed, you can use the following command
+
+```sh
+sudo softwareupdate --install-rosetta --agree-to-license
+```

--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,17 +1,44 @@
 class PactRubyStandalone < Formula
   desc "Standalone pact CLI executable using the Ruby Pact impl and Travelling Ruby"
   homepage "https://github.com/pact-foundation/pact-ruby-standalone"
-  url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-osx.tar.gz"
-  sha256 "dee18427b9eced63a159d5e64c5ff0d7aa2d4a1e67255b24b239c007c2c8b6c1"
+  version "1.92.0"
+  on_macos do
+    on_intel do
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-osx.tar.gz"
+      sha256 "dee18427b9eced63a159d5e64c5ff0d7aa2d4a1e67255b24b239c007c2c8b6c1"
+    end
+    on_arm do
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-osx.tar.gz"
+      sha256 "dee18427b9eced63a159d5e64c5ff0d7aa2d4a1e67255b24b239c007c2c8b6c1"
+    end
+  end
+  on_linux do
+    on_intel do
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-linux-x86_64.tar.gz"
+      sha256 "a5922e4098cae6f8717b9d51fda050d30540dff657c44f61eed9d51875f7822a"
+    end
+  end
 
   def install
+    # pact-ruby-standalone
     bin.install Dir["bin/*"]
     lib.install Dir["lib/*"]
-
     puts "# Run 'pact-mock-service --help' (see https://github.com/pact-foundation/pact-ruby-standalone/releases/)"
+    OS.mac? && Hardware::CPU.arm? do
+      puts "# Rosetta is required to run pact-ruby-standalone commands"
+      puts "# sudo softwareupdate --install-rosetta --agree-to-license"
+    end
   end
 
   test do
+    system "#{bin}/pact", "help"
+    system "#{bin}/pact-broker", "help"
+    system "#{bin}/pact-message", "help"
     system "#{bin}/pact-mock-service", "help"
+    system "#{bin}/pact-plugin-cli", "help"
+    system "#{bin}/pact-mock-service", "help"
+    system "#{bin}/pact-provider-verifier", "help"
+    system "#{bin}/pact-stub-service", "help"
+    system "#{bin}/pactflow", "help"
   end
 end

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -16,18 +16,45 @@ write_homebrew_formulae() {
         echo "class PactRubyStandalone < Formula" >&3
         echo "  desc \"Standalone pact CLI executable using the Ruby Pact impl and Travelling Ruby\"" >&3
         echo "  homepage \"$homepage\"" >&3
-        echo "  url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
-        echo "  sha256 \"${brewshasignature[1]}\"" >&3
+        echo "  version \"$version\"" >&3
+        echo "  on_macos do" >&3
+        echo "    on_intel do" >&3
+        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
+        echo "      sha256 \"${sha_osx_x86_64}\"" >&3
+        echo "    end" >&3
+        echo "    on_arm do" >&3
+        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
+        echo "      sha256 \"${sha_osx_x86_64}\"" >&3
+        echo "    end" >&3
+        echo "  end" >&3
+        echo "  on_linux do" >&3
+        echo "    on_intel do" >&3
+        echo "      url \"$homepage/releases/download/v$version/pact-$version-linux-x86_64.tar.gz\"" >&3
+        echo "      sha256 \"${sha_linux_x86_64}\"" >&3
+        echo "    end" >&3
+        echo "  end" >&3
         echo "" >&3
         echo "  def install" >&3
+        echo "    # pact-ruby-standalone" >&3
         echo "    bin.install Dir[\"bin/*\"]" >&3
         echo "    lib.install Dir[\"lib/*\"]" >&3
-        echo "" >&3
         echo "    puts \"# Run 'pact-mock-service --help' (see $homepage/releases/)\"" >&3
+        echo "    OS.mac? && Hardware::CPU.arm? do" >&3
+        echo "      puts \"# Rosetta is required to run pact-ruby-standalone commands\"" >&3
+        echo "      puts \"# sudo softwareupdate --install-rosetta --agree-to-license\"" >&3
+        echo "    end" >&3
         echo "  end" >&3
         echo "" >&3
         echo "  test do" >&3
+        echo "    system \"#{bin}/pact\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-broker\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-message\", \"help\"" >&3
         echo "    system \"#{bin}/pact-mock-service\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-plugin-cli\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-mock-service\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-provider-verifier\", \"help\"" >&3
+        echo "    system \"#{bin}/pact-stub-service\", \"help\"" >&3
+        echo "    system \"#{bin}/pactflow\", \"help\"" >&3
         echo "  end" >&3
         echo "end" >&3
     exec 3>&-
@@ -38,7 +65,7 @@ display_help() {
 }
 
 display_usage() {
-    echo "\nUsage:\n\"./scripts/update_tap_version.sh 1.64.1\"\n"
+    echo "\nUsage:\n\"CREATE_PR=true ./scripts/update_tap_version.sh 1.64.1\"\n"
 }
 
 if [[ $# -eq 0 ]] ; then
@@ -50,47 +77,72 @@ elif [[ $1 == "--help" ||  $1 == "-h" ]] ; then
     display_usage
     exit 1
 else
-    echo "⬇️  Downloading pact-$version-osx.tar.gz from $homepage"
-    curl -LO $homepage/releases/download/v$version/pact-$version-osx.tar.gz
 
-    brewshasignature=( $(eval "openssl dgst -sha256 pact-$version-osx.tar.gz") )
-    echo "🔏 Checksum SHA256:\t ${brewshasignature[1]}"
+shas=()
+for platform in osx linux; do 
+    for arch in x86_64; do 
+        if [[ ${platform} == "osx" ]]
+        then
+            filename=pact-$version-${platform}
+        else
+            filename=pact-$version-${platform}-${arch}
+        fi
+        echo "⬇️  Downloading $filename.tar.gz from $homepage"
+        curl -LO $homepage/releases/download/v$version/$filename.tar.gz
 
-    shasignature=( $(eval "openssl dgst -sha1 pact-$version-osx.tar.gz") )
-    echo "🔏 Checksum SHA1:\t ${shasignature[1]}"
+        brewshasignature=( $(eval "openssl dgst -sha256 $filename.tar.gz") )
+        echo "🔏 Checksum SHA256:\t ${brewshasignature[1]} for ${arch}"
 
-    echo "⬇️  Downloading pact-$version-osx.tar.gz.checksum"
-    curl -LO $homepage/releases/download/v$version/pact-$version-osx.tar.gz.checksum
+        shasignature=( $(eval "openssl dgst -sha1 $filename.tar.gz") )
+        echo "🔏 Checksum SHA1:\t ${shasignature[1]} for ${platform}-${arch}"
 
-    expectedsha=( $(eval "cat pact-$version-osx.tar.gz.checksum") )
-    echo "🔏 Expected SHA1:\t ${expectedsha[0]}"
+        echo "⬇️  Downloading $filename.tar.gz.checksum for ${platform}-${arch}"
+        curl -LO $homepage/releases/download/v$version/$filename.tar.gz.checksum
 
-    if [ "${shasignature[1]}" == "${expectedsha[0]}" ]; then
-        echo "👮‍♀️ SHA Check: 👍"
-    else
-        echo "👮‍♀️ SHA Check: 🚨 - checksums do not match!"
-        exit 1
-    fi
+        expectedsha=( $(eval "cat $filename.tar.gz.checksum") )
+        echo "🔏 Expected SHA1:\t ${expectedsha[0]} for ${platform}-${arch}"
 
-    echo "🧹 Cleaning up..."
-    rm pact-$1-osx.tar.gz
-    rm pact-$1-osx.tar.gz.checksum
-    echo "🧪 Writing formulae..."
+        if [ "${shasignature[1]}" == "${expectedsha[0]}" ]; then
+            echo "👮‍♀️ SHA Check: 👍 for ${platform}-${arch}"
+        else
+            echo "👮‍♀️ SHA Check: 🚨 - checksums do not match! for ${platform}-${arch}"
+            exit 1
+        fi
+
+        echo "🧹 Cleaning up..."
+        rm $filename.tar.gz
+        rm $filename.tar.gz.checksum
+        echo "🔏 Checksum SHA256:\t ${brewshasignature[1]} for ${platform}-${arch}"
+        echo "🧪 Writing formulae..."
+        shas+=(${brewshasignature[1]})
+    done 
+done 
+
+    sha_osx_x86_64=${shas[0]}
+    sha_linux_x86_64=${shas[1]}
+    echo "sha_osx_x86_64:" $sha_osx_x86_64
+    echo "sha_linux_x86_64:" $sha_linux_x86_64
 
     write_homebrew_formulae
 
-    echo "⚗️  Sorting out the homebrew tap version... "
-    git checkout -b version/v$version
-    git add $FORMULAE_FILE
-    git commit -m "chore(release): Update version to v$version"
-    git push --set-upstream origin version/v$version
+    if [[ ! -n "${CREATE_PR}" ]] 
+    then
+        echo "🎉 Done!"
+    else
+        git checkout -b version/v$version
+        git add $FORMULAE_FILE
+        git commit -m "chore(release): Update version to v$version"
+        git push --set-upstream origin version/v$version
 
-    echo "👏  Go and open that PR now:"
-    echo "🔗  $homepage/compare/master...version/v$version"
+        echo "👏  Go and open that PR now:"
+        echo "🔗  $homepage/compare/master...version/v$version"
 
-    hub pull-request --message "chore(release): Update version to v${version}"
+        hub pull-request --message "chore(release): Update version to v${version}"
+        echo "🎉 Done!"
+    fi
 
-    echo "🎉 Done!"
+
+
 
     exit 0
 fi


### PR DESCRIPTION
Homebrew can be installed on Linux x86_64

https://docs.brew.sh/Homebrew-on-Linux

Pact-Ruby-Standalone provides linux x86_64 packages, this PR adds support (and test pipeline) for Homebrew installed a linux x86_64 machine

Changes will need to run against a pact-foundation branch, rather than a users fork, so have pushed to pact-foundation origin here, github actions run below

https://github.com/pact-foundation/homebrew-pact-ruby-standalone/actions/runs/4683172934