### PR TITLE
Revert "update for v2.0.0 standalone with native ARM support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Pact Ruby Standalone public homebrew tap for OS X homebrew formulae.
 
 The easier way to install [`pact-ruby-standalone`](https://github.com/pact-foundation/pact-ruby-standalone) bundle of tools on your macOS using Homebrew.
 
+
 ## Installation
 
     brew tap pact-foundation/pact-ruby-standalone
@@ -14,9 +15,8 @@ The easier way to install [`pact-ruby-standalone`](https://github.com/pact-found
 | OS           | Architecture | Supported |
 | ------- | ------------ | --------- |
 | OSX        | x86_64       | ✅         |
-| OSX        | arm64 | ✅       |
+| OSX        | aarch64 (arm)| ✅       |
 | Linux    | x86_64       | ✅         |
-| Linux    | arm64       | ✅         |
 
 
 ## Included tools
@@ -31,4 +31,14 @@ The easier way to install [`pact-ruby-standalone`](https://github.com/pact-found
   pact-provider-verifier --help
   pact-stub-service --help
   pactflow --help
+```
+
+### Notes
+
+OSX ARM (M1/M2) Machines will require Rosetta tools, as the Ruby binaries as currently built for x86_64.
+
+If you don't already have it installed, you can use the following command
+
+```sh
+sudo softwareupdate --install-rosetta --agree-to-license
 ```

--- a/pact-ruby-standalone.rb
+++ b/pact-ruby-standalone.rb
@@ -1,25 +1,21 @@
 class PactRubyStandalone < Formula
   desc "Standalone pact CLI executable using the Ruby Pact impl and Travelling Ruby"
   homepage "https://github.com/pact-foundation/pact-ruby-standalone"
-  version "2.0.0"
+  version "1.92.0"
   on_macos do
     on_intel do
-      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.0/pact-2.0.0-osx-x86_64.tar.gz"
-      sha256 "025b1b8de4c99f463960a71ad720b0b92bda19bfed2130cfdd819a2af6c27ee1"
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-osx.tar.gz"
+      sha256 "dee18427b9eced63a159d5e64c5ff0d7aa2d4a1e67255b24b239c007c2c8b6c1"
     end
     on_arm do
-      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.0/pact-2.0.0-osx-arm64.tar.gz"
-      sha256 "d91d2fa7596b20afdd6d1d4f1fe0e1353ceb249892b48b4bbd85a303f7f4ff31"
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-osx.tar.gz"
+      sha256 "dee18427b9eced63a159d5e64c5ff0d7aa2d4a1e67255b24b239c007c2c8b6c1"
     end
   end
   on_linux do
     on_intel do
-      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.0/pact-2.0.0-linux-x86_64.tar.gz"
-      sha256 "42fb3a74a1ca1504b0bbc541d3521a01a32eeb513bf5edceae3ffb9d760d203d"
-    end
-    on_arm do
-      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.0/pact-2.0.0-linux-arm64.tar.gz"
-      sha256 "3a421a35d2ab1da13fc4a99a1506f7243e9702ebacd5cc5fee710cf55e2d5dd5"
+      url "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.92.0/pact-1.92.0-linux-x86_64.tar.gz"
+      sha256 "a5922e4098cae6f8717b9d51fda050d30540dff657c44f61eed9d51875f7822a"
     end
   end
 
@@ -28,6 +24,10 @@ class PactRubyStandalone < Formula
     bin.install Dir["bin/*"]
     lib.install Dir["lib/*"]
     puts "# Run 'pact-mock-service --help' (see https://github.com/pact-foundation/pact-ruby-standalone/releases/)"
+    OS.mac? && Hardware::CPU.arm? do
+      puts "# Rosetta is required to run pact-ruby-standalone commands"
+      puts "# sudo softwareupdate --install-rosetta --agree-to-license"
+    end
   end
 
   test do

--- a/scripts/update_tap_version.sh
+++ b/scripts/update_tap_version.sh
@@ -19,12 +19,12 @@ write_homebrew_formulae() {
         echo "  version \"$version\"" >&3
         echo "  on_macos do" >&3
         echo "    on_intel do" >&3
-        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx-x86_64.tar.gz\"" >&3
+        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
         echo "      sha256 \"${sha_osx_x86_64}\"" >&3
         echo "    end" >&3
         echo "    on_arm do" >&3
-        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx-arm64.tar.gz\"" >&3
-        echo "      sha256 \"${sha_osx_arm64}\"" >&3
+        echo "      url \"$homepage/releases/download/v$version/pact-$version-osx.tar.gz\"" >&3
+        echo "      sha256 \"${sha_osx_x86_64}\"" >&3
         echo "    end" >&3
         echo "  end" >&3
         echo "  on_linux do" >&3
@@ -32,10 +32,6 @@ write_homebrew_formulae() {
         echo "      url \"$homepage/releases/download/v$version/pact-$version-linux-x86_64.tar.gz\"" >&3
         echo "      sha256 \"${sha_linux_x86_64}\"" >&3
         echo "    end" >&3
-        echo "    on_arm do" >&3
-        echo "      url \"$homepage/releases/download/v$version/pact-$version-linux-arm64.tar.gz\"" >&3
-        echo "      sha256 \"${sha_linux_arm64}\"" >&3
-        echo "    end" >&3       
         echo "  end" >&3
         echo "" >&3
         echo "  def install" >&3
@@ -43,6 +39,10 @@ write_homebrew_formulae() {
         echo "    bin.install Dir[\"bin/*\"]" >&3
         echo "    lib.install Dir[\"lib/*\"]" >&3
         echo "    puts \"# Run 'pact-mock-service --help' (see $homepage/releases/)\"" >&3
+        echo "    OS.mac? && Hardware::CPU.arm? do" >&3
+        echo "      puts \"# Rosetta is required to run pact-ruby-standalone commands\"" >&3
+        echo "      puts \"# sudo softwareupdate --install-rosetta --agree-to-license\"" >&3
+        echo "    end" >&3
         echo "  end" >&3
         echo "" >&3
         echo "  test do" >&3
@@ -80,13 +80,18 @@ else
 
 shas=()
 for platform in osx linux; do 
-    for arch in x86_64 arm64; do 
-        filename=pact-$version-${platform}-${arch}
+    for arch in x86_64; do 
+        if [[ ${platform} == "osx" ]]
+        then
+            filename=pact-$version-${platform}
+        else
+            filename=pact-$version-${platform}-${arch}
+        fi
         echo "⬇️  Downloading $filename.tar.gz from $homepage"
         curl -LO $homepage/releases/download/v$version/$filename.tar.gz
 
         brewshasignature=( $(eval "openssl dgst -sha256 $filename.tar.gz") )
-        echo "🔏 Checksum SHA256:\t ${brewshasignature[1]} for ${platform}-${arch}"
+        echo "🔏 Checksum SHA256:\t ${brewshasignature[1]} for ${arch}"
 
         shasignature=( $(eval "openssl dgst -sha1 $filename.tar.gz") )
         echo "🔏 Checksum SHA1:\t ${shasignature[1]} for ${platform}-${arch}"
@@ -114,13 +119,9 @@ for platform in osx linux; do
 done 
 
     sha_osx_x86_64=${shas[0]}
-    sha_osx_arm64=${shas[1]}
-    sha_linux_x86_64=${shas[2]}
-    sha_linux_arm64=${shas[3]}
+    sha_linux_x86_64=${shas[1]}
     echo "sha_osx_x86_64:" $sha_osx_x86_64
-    echo "sha_osx_arm64:" $sha_osx_arm64
     echo "sha_linux_x86_64:" $sha_linux_x86_64
-    echo "sha_linux_arm64:" $sha_linux_arm64
 
     write_homebrew_formulae
 


### PR DESCRIPTION
due to errors identified in https://github.com/pact-foundation/pact-ruby-standalone/issues/101 