### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Test versions
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   test:
@@ -52,9 +56,8 @@ jobs:
           pact-provider-verifier --help
           pact-stub-service --help
           pactflow --help
-        
+
 
       - name: Audit tap
         run: |
           brew audit --strict --online pact-ruby-standalone
-


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.